### PR TITLE
Added missing period

### DIFF
--- a/Trello.psm1
+++ b/Trello.psm1
@@ -309,7 +309,7 @@ function Get-TrelloCardLabel
 	process {
 		try
 		{
-			$uri = "$baseUrl/boards/{0}/labels?{1}" -f $BoardId, $trelloConfig.String
+			$uri = "$baseUrl/boards/{0}/labels?{1}" -f $Board.Id, $trelloConfig.String
 			Invoke-RestMethod -Uri $uri
 		}
 		catch


### PR DESCRIPTION
Without it one would receive error:

```
Get-TrelloCardLabel : The variable '$BoardId' cannot be retrieved because it has not been set.
```
