### PR TITLE
Added function to rename cards

### DIFF
--- a/PowerTrello.psm1
+++ b/PowerTrello.psm1
@@ -1043,3 +1043,37 @@ function Rename-TrelloBoardList
 		}
 	}
 }
+
+
+function Rename-TrelloBoardCard
+{
+    [CmdletBinding()]
+  param
+    (
+      [Parameter(Mandatory, ValueFromPipeline)]
+      [ValidateNotNullOrEmpty()]
+      [object]$Board,
+      [ValidateNotNullOrEmpty()]
+      [string]$NewName,
+      [ValidateNotNullOrEmpty()]
+      [string]$Id
+	)
+
+
+    begin
+	{
+		$ErrorActionPreference = 'Stop'
+	}
+	process
+	{
+		try
+		{
+            $uri = "$baseUrl/cards/{0}?name={1}&idBoard={2}&{3}" -f $Id, $NewName, $($Board.Id), $trelloConfig.String
+            Invoke-RestMethod -Uri $uri -Method Put
+		}
+		catch
+		{
+			Write-Error $_.Exception.Message
+		}
+	}
+}


### PR DESCRIPTION
Example usage:
Get-TrelloBoard -Name $Board | Rename-TrelloBoardCard -NewName $name -Id $EstimateCardID

Uses long ID for cards, obtainable by for example:
(Get-TrelloBoard -name $Board | Get-Trellocard | ? { $_.name -like $cardtext+"*"}).id